### PR TITLE
Feature/168 node list graphics fix

### DIFF
--- a/Src/Config/Annotations/anot_figure.py
+++ b/Src/Config/Annotations/anot_figure.py
@@ -14,6 +14,9 @@ from Src.Config.Annotations import AParam
 from Src.Enums import DPGType
 from Src.Utils import instancelessmethod
 
+TEXTURE_WIDTH = 400
+TEXTURE_HEIGHT = 300
+
 
 @dataclass
 class AFigure(AParam):
@@ -26,18 +29,24 @@ class AFigure(AParam):
         if not dpg.does_alias_exist("figure_texture_registry"):
             dpg.add_texture_registry(tag="figure_texture_registry")
 
+        width: int = kwargs.get("width") or TEXTURE_WIDTH
+        height: int = round(width * TEXTURE_HEIGHT / TEXTURE_WIDTH)
+
         tex_id: int | str = dpg.generate_uuid()
         dpg.add_dynamic_texture(
-            width=400,
-            height=300,
-            default_value=np.full((300, 400, 4), 0.5, dtype=np.float32).flatten(),
+            width=TEXTURE_WIDTH,
+            height=TEXTURE_HEIGHT,
+            default_value=np.full(
+                (TEXTURE_HEIGHT, TEXTURE_WIDTH, 4), 0.5, dtype=np.float32
+            ).flatten(),
             tag=tex_id,
             parent="figure_texture_registry",
         )
 
         dpg.add_text(kwargs.get("label") or "Figure", show=not self.display)
-        return dpg.add_image(tex_id, user_data=tex_id, show=self.display)
-
+        return dpg.add_image(
+            tex_id, width=width, height=height, user_data=tex_id, show=self.display
+        )
 
     @staticmethod
     def get(input_id: int | str) -> Any:
@@ -54,7 +63,6 @@ class AFigure(AParam):
             results.append(getattr(node, label))
 
         return results[0] if results else None
-
 
     @instancelessmethod
     def set(self, input_id: int | str, fig: plt.Figure) -> bool:

--- a/Src/Config/Annotations/aparam.py
+++ b/Src/Config/Annotations/aparam.py
@@ -9,29 +9,31 @@ from Src.Utils.instancelessmethod import instancelessmethod
 
 
 class AParam(Annotation, ABC):
-
     @instancelessmethod
-    def _build(self, *args, **kwargs) -> str | int: pass
+    def _build(self, *args, **kwargs) -> str | int:
+        pass
 
     @instancelessmethod
     def build(self, *args, **kwargs) -> str | int:
-        if DPGType(kwargs['parent']) != DPGType.NODE_ATTRIBUTE:
+        if DPGType(kwargs["parent"]) != DPGType.NODE_ATTRIBUTE:
             return self._build(*args, **kwargs)
 
-        new_parent = dpg.get_item_parent(kwargs['parent'])
-        dpg.delete_item(kwargs['parent'])
+        new_parent = dpg.get_item_parent(kwargs["parent"])
+        dpg.delete_item(kwargs["parent"])
 
-        kwargs = Annotation.check_kwargs(dpg.node_attribute, kwargs)
-        kwargs['parent'] = new_parent
-        kwargs['user_data'] = []
+        attribute_kwargs = Annotation.check_kwargs(dpg.node_attribute, kwargs)
+        attribute_kwargs["parent"] = new_parent
+        attribute_kwargs["user_data"] = []
 
-        if 'attribute_type' not in kwargs.keys():
-            kwargs['attribute_type'] = dpg.mvNode_Attr_Input
+        if "attribute_type" not in attribute_kwargs.keys():
+            attribute_kwargs["attribute_type"] = dpg.mvNode_Attr_Input
 
-        with dpg.node_attribute(*args, **kwargs) as attr:
+        kwargs["parent"] = new_parent
+
+        with dpg.node_attribute(*args, **attribute_kwargs) as attr:
             input_id = self._build(*args, **kwargs)
 
-        if hasattr(self.node_type, 'theme_name'):
+        if hasattr(self.node_type, "theme_name"):
             ThemeManager.apply_theme(attr, self.node_type.theme_name)
 
         return input_id

--- a/Src/node_builder.py
+++ b/Src/node_builder.py
@@ -8,7 +8,7 @@ from keras import layers
 from Src.Enums.attr_type import AttrType
 from Src.Logging import logging, Logger
 from Src.Nodes import AbstractNode, InputLayerNode, LayerNode
-from Src.Config.node_list import NodeAnnotation, Parameter, ANode, Single
+from Src.Config.node_list import NodeAnnotation, Parameter, ANode, Single, AFigure
 from Src.Config.Annotations.annotation import Annotation
 from Src.Managers import ThemeManager
 from Src.Enums import Themes
@@ -78,16 +78,12 @@ class NodeBuilder:
 
         params = [(label, param) for label, param in node_data.annotations.items() if label != 'INPUT']
 
-        items_count = len(params)
-        if node_data.input: items_count += 1
-        if node_data.output: items_count += 1
-        calc_height = 80 + (items_count * 26)
-
         with dpg.child_window(
             tag=card_id,
             parent=parent,
             width=self.card_width,
-            height=calc_height,
+            auto_resize_y=True,
+            always_auto_resize=True,
             no_scrollbar=True,
             border=True,
             user_data=node_data
@@ -145,9 +141,13 @@ class NodeBuilder:
                         dpg.add_text(node_data.docs, wrap=self.card_width - 30)
 
                     for label, param in params:
-                        parameter = param.hint.build(label=label, parent=body_group, width=Annotation.BASE_WIDTH, enabled=False)
-                        if parameter:
-                            ThemeManager.apply_theme(parameter, Themes.DEFAULT)
+                        hint = param.hint
+                        if isinstance(hint, AFigure):
+                            dpg.add_text(f"[figure] {label}")
+                        else:
+                            parameter = hint.build(label=label, parent=body_group, width=Annotation.BASE_WIDTH, enabled=False)
+                            if parameter:
+                                ThemeManager.apply_theme(parameter, Themes.DEFAULT)
 
                     delete_button = dpg.add_button(label="Delete")
                     ThemeManager.apply_theme(delete_button, Themes.DEFAULT)

--- a/Src/node_builder.py
+++ b/Src/node_builder.py
@@ -8,7 +8,7 @@ from keras import layers
 from Src.Enums.attr_type import AttrType
 from Src.Logging import logging, Logger
 from Src.Nodes import AbstractNode, InputLayerNode, LayerNode
-from Src.Config.node_list import NodeAnnotation, Parameter, ANode, Single, AFigure
+from Src.Config.node_list import NodeAnnotation, Parameter, ANode, Single
 from Src.Config.Annotations.annotation import Annotation
 from Src.Managers import ThemeManager
 from Src.Enums import Themes
@@ -142,12 +142,9 @@ class NodeBuilder:
 
                     for label, param in params:
                         hint = param.hint
-                        if isinstance(hint, AFigure):
-                            dpg.add_text(f"[figure] {label}")
-                        else:
-                            parameter = hint.build(label=label, parent=body_group, width=Annotation.BASE_WIDTH, enabled=False)
-                            if parameter:
-                                ThemeManager.apply_theme(parameter, Themes.DEFAULT)
+                        parameter = hint.build(label=label, parent=body_group, width=Annotation.BASE_WIDTH, enabled=False)
+                        if parameter:
+                            ThemeManager.apply_theme(parameter, Themes.DEFAULT)
 
                     delete_button = dpg.add_button(label="Delete")
                     ThemeManager.apply_theme(delete_button, Themes.DEFAULT)
@@ -158,21 +155,33 @@ class NodeBuilder:
         dpg.add_spacer(height=10)
         return card_id
 
-    def build_node(self, node_data: NodeAnnotation, parent: str | int) -> str | int:
+    def build_node(self, node_data: NodeAnnotation, parent: str | int, min_width: int | None = None) -> str | int:
         '''
         Построение dpg.node из класса AbstractNode. Используется, для создания новых нодов в редакторе. Ноды берутся из user_data в списке слева.
 
         Args:
             node: AbstractNode - нода из которой создать dpg.node
             parent: str | int - родитель, внутри которого создать ноду. Чаще всего это dpg.node_editor.
+            min_width: int | None - минимальная ширина ноды (чтобы визуально совпадала с карточкой в списке).
+                                     None - использовать self.card_width, 0 - не задавать минимальную ширину.
 
         Returns:
             str | int - индетификатор новой dpg.node.
         '''
+        if min_width is None:
+            min_width = self.card_width
+
         node_id = dpg.generate_uuid()
         node: AbstractNode = node_data.node_type(node_id, **node_data.kwargs)
 
         with dpg.node(label=node_data.label, parent=parent, user_data=node, tag=node_id):
+            if min_width:
+                # Невидимый спейсер, задающий такую же минимальную ширину ноды,
+                # как у карточки в списке слева (min_width), т.к. у dpg.node
+                # нет собственного параметра width - ширина считается по самому широкому контенту.
+                with dpg.node_attribute(attribute_type=dpg.mvNode_Attr_Static):
+                    dpg.add_spacer(width=min_width)
+
             if node_data.input:
                 node_data.input.build(label="INPUT", parent=node_id)
 
@@ -219,7 +228,7 @@ class NodeBuilder:
             output=LayerNode
             )
 
-        node_id = self.build_node(layer, parent=parent)
+        node_id = self.build_node(layer, parent=parent, min_width=0)
 
         return node_id
 


### PR DESCRIPTION
### 📝 Описание изменений (What's new)
- Удалены переменные items_count и calc_height — ручной расчёт высоты убран полностью
- В child_window заменён аргумент height=calc_height на auto_resize_y=True, always_auto_resize=True — DPG теперь сам вычисляет высоту по содержимому
- Добавлен импорт AFigure для проверки типа аннотации в цикле рендера параметров
- В цикле отрисовки параметров добавлена ветка для AFigure: вместо полноразмерного изображения рендерится текстовая метка [figure] {label}, так как изображение 400px шире card_width (371px) и вызывает горизонтальное переполнение

Сейчас мне нужно помощь с тем как пофиксить переполнение. 
<img width="448" height="532" alt="image" src="https://github.com/user-attachments/assets/36296eb1-cfb1-451a-9714-3d04e4fddd11" />

Временное решение с dpg.add_text(f"[figure] {label}") — это заглушка.

Корневая причина: AFigure._build в anot_figure.py создаёт текстуру с фиксированными размерами 400×300 и рендерит dpg.add_image без указания ширины — DPG использует натуральный размер текстуры (400px), который превышает card_width (371px).

Как лучше передать доступную ширину контейнера в AFigure._build без хардкода?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлены загрузка аудио и текста, визуализация данных: линейные графики, столбчатые диаграммы, гистограммы и scatter plot.
  * Реализовано сохранение построенных графиков в файл.
  * Обновлены карточки узлов: добавлены перетаскивание, документация, параметры, маркеры входов и выходов.
  * Расширены настройки тем для боковой панели, карточек узлов и графиков.
* **Документация**
  * README обновлён на русском и английском языках; добавлены инструкции запуска, тестирования и сборки.
* **Тесты**
  * Расширено покрытие тестами; добавлена автоматическая проверка покрытия не ниже 80%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->