### PR TITLE
#181 Done Add native file dialog via tkinter to support Cyrillic paths

### DIFF
--- a/Src/Config/Annotations/anot_file.py
+++ b/Src/Config/Annotations/anot_file.py
@@ -12,10 +12,11 @@ class AFile(Annotation):
 
     @staticmethod
     def build(*args, **kwargs):
+        label = kwargs.pop('label', None)
         kwargs = Annotation.check_kwargs(dpg.node_attribute, kwargs)
         group_id = dpg.generate_uuid()
 
-        with dpg.group(*args, **kwargs, tag=group_id, user_data=None) as item:
+        with dpg.group(*args, **kwargs, label=label, tag=group_id, user_data=None) as item:
             dpg.add_button(
                 label="Choose file...",
                 callback=lambda: open_file_dialog(

--- a/Src/Config/Annotations/anot_file.py
+++ b/Src/Config/Annotations/anot_file.py
@@ -4,6 +4,7 @@ import dearpygui.dearpygui as dpg
 
 from Src.Config.Annotations.annotation import Annotation
 from Src.Enums import DPGType
+from Src.Utils.file_dialog import open_file_dialog
 
 
 class AFile(Annotation):
@@ -12,29 +13,26 @@ class AFile(Annotation):
     @staticmethod
     def build(*args, **kwargs):
         kwargs = Annotation.check_kwargs(dpg.node_attribute, kwargs)
-        browser_id = dpg.generate_uuid()
         group_id = dpg.generate_uuid()
 
-        with dpg.file_dialog(directory_selector=False, show=False, modal=True, \
-                              width=1400 ,height=800, tag=browser_id, 
-                              callback=lambda _, appdata: 
-                                dpg.set_item_user_data(group_id, 
-                                        list(map(Path, appdata['selections'].values())))):
-            dpg.add_file_extension(".*")
-
         with dpg.group(*args, **kwargs, tag=group_id, user_data=None) as item:
-            dpg.add_button(label="Choose file...", callback=lambda: dpg.show_item(browser_id))
+            dpg.add_button(
+                label="Choose file...",
+                callback=lambda: open_file_dialog(
+                    callback=lambda result: dpg.set_item_user_data(group_id, result),
+                ),
+            )
 
         return item
-    
+
 
     @staticmethod
     def get(input_id: int | str):
         if DPGType(input_id) != DPGType.GROUP:
-            raise Exception(f"Incompatable item for AFile.get - {dpg.get_item_type(input_id)}") 
-        
+            raise Exception(f"Incompatable item for AFile.get - {dpg.get_item_type(input_id)}")
+
         return dpg.get_item_user_data(input_id)
-    
+
 
     @staticmethod
     def set(input_id: str| int, value: Path) -> bool:
@@ -42,6 +40,6 @@ class AFile(Annotation):
             all(isinstance(sub, Path) for sub in value) and \
             DPGType(input_id) == DPGType.GROUP):
             return False
-        
+
         dpg.set_item_user_data(input_id, value)
         return True

--- a/Src/Config/node_list.py
+++ b/Src/Config/node_list.py
@@ -23,7 +23,7 @@ node_list = {
                 node_type = ShapeNode,
                 logic = ShapeNode.open_table_data,
                 annotations = {
-                        "files": Parameter(AttrType.INPUT, AString),
+                        "files": Parameter(AttrType.INPUT, AFile),
                         "delimiter": Parameter(AttrType.INPUT, AEnum[Delimiters]),
                         "skip_header": Parameter(AttrType.INPUT, ABoolean),
                         "skip_footer": Parameter(AttrType.INPUT, ABoolean),
@@ -39,7 +39,7 @@ node_list = {
                 node_type= ShapeNode,
                 logic = ShapeNode.open_image_data,
                 annotations = {
-                        "files": Parameter(AttrType.INPUT, AString),
+                        "files": Parameter(AttrType.INPUT, AFile),
                         "color_mode": Parameter(AttrType.INPUT, AEnum[ColorMode]),
                         "shape": Parameter(AttrType.OUTPUT, ASequence[AInteger, AInteger, AInteger])
                         },

--- a/Src/Nodes/shape_node.py
+++ b/Src/Nodes/shape_node.py
@@ -27,17 +27,20 @@ class ShapeNode(DataNode):
 
 
     @staticmethod
-    def open_table_data(files: str, *args, **kwargs):
-        if not files: 
+    def open_table_data(files, *args, **kwargs):
+        if not files:
             raise AttributeError("Вы не выбрали данные, которые нужно открыть!")
-        
+        if isinstance(files, list):
+            files = str(files[0])
         return np.genfromtxt(files, *args, **kwargs, ndmin=2)
 
     
     @staticmethod
-    def open_image_data(files: str, *args, **kwargs):
-        if not files: 
+    def open_image_data(files, *args, **kwargs):
+        if not files:
             raise AttributeError("Вы не выбрали данные, которые нужно открыть!")
+        if isinstance(files, list):
+            files = str(files[0])
 
         images = []
         for image_path in sorted(Path(files).iterdir()):
@@ -49,9 +52,11 @@ class ShapeNode(DataNode):
     
     
     @staticmethod
-    def open_audio_data(files: str, NFFT: int = 1024, noverlap: int = 512, max_duration_sec: float = 5.0,sr: int = None, mono: bool = True):
+    def open_audio_data(files, NFFT: int = 1024, noverlap: int = 512, max_duration_sec: float = 5.0,sr: int = None, mono: bool = True):
         if not files:
             raise AttributeError("Вы не выбрали данные, которые нужно открыть!")
+        if isinstance(files, list):
+            files = str(files[0])
         
         audios = []
         
@@ -77,9 +82,11 @@ class ShapeNode(DataNode):
     
 
     @staticmethod
-    def open_text_data(files: str, output_mode: TextOutputMode = TextOutputMode.INT, max_tokens: int = 20000,split: SplitMode = SplitMode.WHITESPACE):
-        if not files: 
+    def open_text_data(files, output_mode: TextOutputMode = TextOutputMode.INT, max_tokens: int = 20000,split: SplitMode = SplitMode.WHITESPACE):
+        if not files:
             raise AttributeError("Вы не выбрали данные, которые нужно открыть!")
+        if isinstance(files, list):
+            files = str(files[0])
         
         texts = []
         for text_path in sorted(Path(files).iterdir()):

--- a/Src/Utils/__init__.py
+++ b/Src/Utils/__init__.py
@@ -2,3 +2,4 @@ from Src.Utils.factory_method import factorymethod
 from Src.Utils.backfield import Backfield
 from Src.Utils.singleton import singleton
 from Src.Utils.instancelessmethod import instancelessmethod
+from Src.Utils.file_dialog import open_file_dialog

--- a/Src/Utils/file_dialog.py
+++ b/Src/Utils/file_dialog.py
@@ -1,0 +1,41 @@
+import threading
+import tkinter as tk
+from tkinter import filedialog
+from pathlib import Path
+from typing import Callable, Optional
+
+
+def open_file_dialog(
+    callback: Callable[[Optional[list[Path]]], None],
+    title: str = "Выберите файл",
+    filetypes: list[tuple[str, str]] | None = None,
+    directory: bool = False,
+    multi: bool = False,
+) -> None:
+    """Вызывает нативный файловый диалог ОС в отдельном потоке."""
+    if filetypes is None:
+        filetypes = [("All files", "*.*")]
+
+    def _run_dialog():
+        root = tk.Tk()
+        root.withdraw()
+        root.wm_attributes('-topmost', 1)
+
+        result = None
+        if directory:
+            path = filedialog.askdirectory(title=title)
+            if path:
+                result = [Path(path)]
+        elif multi:
+            paths = filedialog.askopenfilenames(title=title, filetypes=filetypes)
+            if paths:
+                result = [Path(p) for p in paths]
+        else:
+            path = filedialog.askopenfilename(title=title, filetypes=filetypes)
+            if path:
+                result = [Path(path)]
+
+        root.destroy()
+        callback(result)
+
+    threading.Thread(target=_run_dialog, daemon=True).start()

--- a/Tests/test_compilation.py
+++ b/Tests/test_compilation.py
@@ -50,8 +50,8 @@ def test_compilation(node_editor):
     node_editor.link_callback("node_editor", (get_attr("OUTPUT", dataX), get_attr("x", predict)))
     node_editor.link_callback("node_editor", (get_attr("OUTPUT", predict), get_attr("X", save)))
 
-    assert AString.set(dpg.get_item_children(get_attr("files", dataX), slot=1)[0], "./Tests/X.txt")
-    assert AString.set(dpg.get_item_children(get_attr("files", dataY), slot=1)[0], "./Tests/y.txt")
+    assert AFile.set(dpg.get_item_children(get_attr("files", dataX), slot=1)[0], [Path("./Tests/X.txt")])
+    assert AFile.set(dpg.get_item_children(get_attr("files", dataY), slot=1)[0], [Path("./Tests/y.txt")])
     assert AInteger.set(dpg.get_item_children(get_attr("num_classes", categorical), slot=1)[0], 2)
     assert AInteger.set(dpg.get_item_children(get_attr("units", dense), slot=1)[0], 2)
     assert AEnum[Activations].set(dpg.get_item_children(get_attr("activation", dense), slot=1)[0], Activations.SOFTMAX)


### PR DESCRIPTION
### Описание изменений (What's new)
Заменил встроенный `dpg.file_dialog()` на нативный диалог ОС через tkinter. Встроенный диалог DearPyGui падал на путях с кириллицей, нативный работает корректно.

- `Src/Utils/file_dialog.py` — модуль с `open_file_dialog()`, запускает tkinter filedialog в отдельном потоке
- `Src/Config/Annotations/anot_file.py` — переписан на использование `open_file_dialog`
- `Src/Config/node_list.py` — подключён `AFile` к нодам Tables data и Images data

### Как протестировать (How to test)
1. Запустить `python main.py`
2. Data & Preprocessing → Import data → перетащить Tables data или Images data
3. Нажать "Choose file..." — откроется нативный проводник
4. Выбрать файл из папки с русским названием — не должно быть краша

---
Закрывает - #181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлен нативный диалог выбора файлов и каталогов.
  * Поддерживается выбор одного или нескольких файлов, а также отмена выбора.
  * Параметры загрузки табличных и графических данных теперь используют выбор файлов.
  * Выбранные файлы передаются в обработку как список путей.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->