### PR TITLE
[BUG]: Исправить пути ресурсов PyInstaller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ PYINSTALLER_OPTS = \
 # ; - разделитель
 # . - означает корень собранного приложения
 ADD_DATA = \
-	--add-data "notomono-regular.ttf;." \
-	--add-data "Src/Logging/logger_config.json;Src/Logging"
+	--add-data "Assets;Assets"
 
 # Команда по умолчанию, выполняется при вызове "make" без аргументов
 all: build


### PR DESCRIPTION
📝 Описание бага
В Makefile ресурсы для PyInstaller подключаются из неверных путей: шрифт указан в корне проекта, а конфигурация логирования в Src/Logging.

Фактически необходимые ресурсы находятся в Assets. Из-за этого собранное приложение не может загрузить шрифт, темы и конфигурацию логирования через sys._MEIPASS.

🎯 Точка входа
Makefile:24

Fixes #193