### PR TITLE
#96 Package GraphNet for pip installation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,3 +32,18 @@ jobs:
 
       - name: Coverage report
         run: uv run coverage report -m --fail-under=80
+
+      - name: Build wheel and source distribution
+        run: uv build
+
+      - name: Install wheel in a clean environment
+        run: |
+          uv venv "$RUNNER_TEMP/graphnet-wheel" --python 3.12
+          uv pip install --python "$RUNNER_TEMP/graphnet-wheel/bin/python" dist/*.whl
+
+      - name: Smoke test installed application outside checkout
+        env:
+          GRAPHNET_LOG_DIR: ${{ runner.temp }}/graphnet-logs
+        run: |
+          cd "$RUNNER_TEMP"
+          xvfb-run -a "$RUNNER_TEMP/graphnet-wheel/bin/graphnet" --smoke-test

--- a/README.md
+++ b/README.md
@@ -77,6 +77,30 @@ uv run main.py
 
 ---
 
+## Install with pip (Python 3.12)
+
+Install a local checkout:
+
+```bash
+python -m pip install .
+graphnet
+```
+
+Once this change is merged into `develop`, install directly from GitHub:
+
+```bash
+python -m pip install "git+https://github.com/graphicalAI/graphNet.git@develop"
+graphnet
+```
+
+Git is required for installation from GitHub. A built wheel can also be installed
+with `python -m pip install path/to/graphnet_constructor-0.1.0-py3-none-any.whl`.
+The command works outside the source directory. Fonts, themes and logging
+configuration are included in the wheel. Logs are written to `~/.graphnet/logs`;
+set `GRAPHNET_LOG_DIR` to choose another directory. A graphical desktop is required.
+`graphnet --smoke-test` starts the editor and exits after three rendered frames.
+Build distributable archives with `uv build`.
+
 ## 🧪 Testing & Coverage
 
 The project uses **pytest** for automated testing. Thanks to the configuration in `pyproject.toml`, you do not need to manually configure `PYTHONPATH` or test directories.
@@ -192,6 +216,30 @@ uv run main.py
 *`uv` автоматически создаст виртуальное окружение, загрузит необходимую версию Python (>=3.12.0), установит зависимости (Dear PyGui, NumPy, Pillow, PyDot, TensorFlow) и запустит проект.*
 
 ---
+
+## Установка через pip (Python 3.12)
+
+Установите локальный checkout:
+
+```bash
+python -m pip install .
+graphnet
+```
+
+После слияния этого изменения в `develop` доступна установка прямо из GitHub:
+
+```bash
+python -m pip install "git+https://github.com/graphicalAI/graphNet.git@develop"
+graphnet
+```
+
+Для установки из GitHub нужен Git. Готовый wheel можно установить командой
+`python -m pip install path/to/graphnet_constructor-0.1.0-py3-none-any.whl`.
+Запуск не зависит от текущей папки. Шрифты, темы и конфигурация логгера входят
+в wheel. Логи сохраняются в `~/.graphnet/logs`; переменная `GRAPHNET_LOG_DIR`
+позволяет выбрать другую папку. Нужен графический рабочий стол.
+`graphnet --smoke-test` запускает редактор и завершает его после трёх кадров.
+Архивы собираются командой `uv build`.
 
 ## 🧪 Тестирование и покрытие (Coverage)
 

--- a/README.md
+++ b/README.md
@@ -233,12 +233,11 @@ python -m pip install "git+https://github.com/graphicalAI/graphNet.git@develop"
 graphnet
 ```
 
-Для установки из GitHub нужен Git. Готовый wheel можно установить командой
+Готовый wheel можно установить командой
 `python -m pip install path/to/graphnet_constructor-0.1.0-py3-none-any.whl`.
-Запуск не зависит от текущей папки. Шрифты, темы и конфигурация логгера входят
-в wheel. Логи сохраняются в `~/.graphnet/logs`; переменная `GRAPHNET_LOG_DIR`
-позволяет выбрать другую папку. Нужен графический рабочий стол.
-`graphnet --smoke-test` запускает редактор и завершает его после трёх кадров.
+Логи сохраняются в `~/.graphnet/logs`; переменная `GRAPHNET_LOG_DIR`
+позволяет выбрать другую папку.
+`graphnet --smoke-test` для smoke-тестов.
 Архивы собираются командой `uv build`.
 
 ## 🧪 Тестирование и покрытие (Coverage)

--- a/Src/Logging/__init__.py
+++ b/Src/Logging/__init__.py
@@ -1,11 +1,19 @@
+import os
+from pathlib import Path
+
 from Src.Logging.logger_factory import Logger_factory as logging, Logger
+from Src.resources import resource_path
 
-logging(logging.open_config("Assets/logger_config.json", False))
+config = logging.open_config(resource_path("logger_config.json"), False)
+log_directory = Path(os.environ.get("GRAPHNET_LOG_DIR", Path.home() / ".graphnet" / "logs")).expanduser()
+log_directory.mkdir(parents=True, exist_ok=True)
+config["filename"] = str(log_directory / Path(config["filename"]).name)
+logging(config)
 
-debug_config = logging.open_config('Assets/logger_debug.json')
-group_config = logging.open_config('Assets/logger_group.json')
-stream_config = logging.open_config('Assets/logger_stream.json')
+debug_config = logging.open_config(resource_path("logger_debug.json"))
+group_config = logging.open_config(resource_path("logger_group.json"))
+stream_config = logging.open_config(resource_path("logger_stream.json"))
 
-logging()('main', group_config)
-logging()('nodes', group_config | debug_config)
-logging()('functions', group_config | debug_config)
+logging()("main", group_config)
+logging()("nodes", group_config | debug_config)
+logging()("functions", group_config | debug_config)

--- a/Src/Logging/logger_factory.py
+++ b/Src/Logging/logger_factory.py
@@ -31,7 +31,8 @@ class Logger_factory:
         path = Logger_factory.BASE_PATH / path
         config = {}
         if path.exists():
-            config = json.load(path.open())
+            with path.open(encoding="utf-8") as config_file:
+                config = json.load(config_file)
         elif not exist_ok: 
             raise FileExistsError(f"Обязательный конфигурационный файл отсутствует: {path}")
 

--- a/Src/application.py
+++ b/Src/application.py
@@ -1,0 +1,48 @@
+"""GraphNet application entry point."""
+import argparse
+
+from Src.resources import resource_path
+
+
+def main():
+    """Launch the editor, optionally exiting after three frames for smoke tests."""
+    parser = argparse.ArgumentParser(description="GraphNet neural network constructor")
+    parser.add_argument(
+        "--smoke-test", action="store_true",
+        help="initialize the editor, render three frames and exit",
+    )
+    args = parser.parse_args()
+
+    import dearpygui.dearpygui as dpg
+    from Src.Logging import logging
+    from Src.Managers import ThemeManager
+    from Src.node_editor import NodeEditor
+
+    dpg.create_context()
+    try:
+        dpg.create_viewport(title="GraphNet")
+        ThemeManager.load_themes(resource_path("themes.json"))
+        node_editor = NodeEditor(
+            minimap=True, minimap_location=dpg.mvNodeMiniMap_Location_TopRight,
+        )
+        main_logger = logging()("main")
+        with dpg.font_registry():
+            with dpg.font(str(resource_path("notomono-regular.ttf")), 18,
+                          default_font=True, tag="Default font"):
+                dpg.add_font_range_hint(dpg.mvFontRangeHint_Cyrillic)
+        dpg.bind_font("Default font")
+
+        with dpg.window(tag="Prime"):
+            node_editor.show("Prime")
+            main_logger.warning("НАЧАЛИ")
+
+        dpg.setup_dearpygui()
+        dpg.show_viewport()
+        dpg.set_primary_window("Prime", True)
+        if args.smoke_test:
+            for _ in range(3):
+                dpg.render_dearpygui_frame()
+        else:
+            dpg.start_dearpygui()
+    finally:
+        dpg.destroy_context()

--- a/Src/resources.py
+++ b/Src/resources.py
@@ -1,0 +1,10 @@
+"""Paths to application resources in a checkout, wheel or frozen bundle."""
+from pathlib import Path
+
+
+def resource_path(filename: str) -> Path:
+    """Return a resource path independently of the working directory."""
+    package_assets = Path(__file__).resolve().parent / "Assets"
+    if package_assets.is_dir():
+        return package_assets / filename
+    return Path(__file__).resolve().parent.parent / "Assets" / filename

--- a/Tests/test_packaging.py
+++ b/Tests/test_packaging.py
@@ -1,0 +1,50 @@
+import importlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import dearpygui.dearpygui as dpg
+import pytest
+
+from Src.resources import resource_path
+
+
+@pytest.mark.parametrize("filename", [
+    "themes.json", "logger_config.json", "logger_debug.json",
+    "logger_group.json", "logger_stream.json", "notomono-regular.ttf",
+])
+def test_resources_do_not_depend_on_working_directory(tmp_path, monkeypatch, filename):
+    monkeypatch.chdir(tmp_path)
+    path = resource_path(filename)
+    assert path.is_file()
+    if path.suffix == ".json":
+        assert isinstance(json.loads(path.read_text(encoding="utf-8")), dict)
+    else:
+        assert path.stat().st_size > 0
+
+
+def test_importing_entry_point_does_not_create_gui(monkeypatch):
+    def unexpected_context():
+        pytest.fail("Importing the entry point must not open the GUI")
+    monkeypatch.setattr(dpg, "create_context", unexpected_context)
+    module = importlib.import_module("Src.application")
+    importlib.reload(module)
+    assert callable(module.main)
+
+
+def test_logging_uses_user_directory_outside_checkout(tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    log_directory = tmp_path / "nested" / "logs"
+    env = os.environ | {"PYTHONPATH": str(root), "GRAPHNET_LOG_DIR": str(log_directory)}
+    script = (
+        "from Src.Logging import config, logging; "
+        "from pathlib import Path; "
+        "assert Path(config['filename']).parent == Path(__import__('os').environ['GRAPHNET_LOG_DIR']); "
+        "logging()('main').warning('packaging-check')"
+    )
+    subprocess.run([sys.executable, "-c", script], cwd=tmp_path, env=env,
+                   capture_output=True, text=True, check=True)
+    assert any("packaging-check" in p.read_text() for p in log_directory.glob("*.log"))
+    assert not (tmp_path / "Logs").exists()

--- a/main.py
+++ b/main.py
@@ -1,42 +1,5 @@
-import json
-import sys
-from pathlib import Path
-
-import dearpygui.dearpygui as dpg
-
-from Src.Logging import logging
-from Src.Managers import ThemeManager
-from Src.node_editor import NodeEditor
+from Src.application import main
 
 
-dpg.create_context()
-dpg.create_viewport(title='Custom Title')
-
-base_path = Path(sys._MEIPASS if hasattr(sys, '_MEIPASS') else '.')
-font_path = base_path / "Assets/notomono-regular.ttf"
-themes_path = base_path / "Assets/themes.json"
-
-ThemeManager.load_themes(themes_path)
-node_editor = NodeEditor(minimap=True, minimap_location=dpg.mvNodeMiniMap_Location_TopRight)
-main_logger = logging()("main")
-
-
-
-with dpg.font_registry():
-    with dpg.font(font_path, 18, default_font=True, tag="Default font") as f:
-        dpg.add_font_range_hint(dpg.mvFontRangeHint_Cyrillic)
-dpg.bind_font("Default font")
-
-with dpg.window(tag="Prime"):
-    node_editor.show("Prime")
-    main_logger.warning("НАЧАЛИ")
-
-
-dpg.setup_dearpygui()
-dpg.show_viewport()
-dpg.set_primary_window("Prime", True)
-dpg.set_global_font_scale(1)
-dpg.start_dearpygui()
-
-
-dpg.destroy_context()
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "graphnet"
+name = "graphnet-constructor"
 version = "0.1.0"
-description = "Add your description here"
+description = "Visual neural network constructor built with Dear PyGui and Keras"
 readme = "README.md"
 requires-python = "~=3.12.0"
 dependencies = [
@@ -35,3 +35,28 @@ exclude_also = [
     "raise NotImplementedError",
     "if __name__ == .__main__.:",
 ]
+
+[build-system]
+requires = ["hatchling>=1.27,<2"]
+build-backend = "hatchling.build"
+
+[project.scripts]
+graphnet = "Src.application:main"
+
+[project.urls]
+Homepage = "https://github.com/graphicalAI/graphNet"
+Issues = "https://github.com/graphicalAI/graphNet/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["Src"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"Assets/notomono-regular.ttf" = "Src/Assets/notomono-regular.ttf"
+"Assets/themes.json" = "Src/Assets/themes.json"
+"Assets/logger_config.json" = "Src/Assets/logger_config.json"
+"Assets/logger_debug.json" = "Src/Assets/logger_debug.json"
+"Assets/logger_group.json" = "Src/Assets/logger_group.json"
+"Assets/logger_stream.json" = "Src/Assets/logger_stream.json"
+
+[tool.hatch.build.targets.sdist]
+include = ["/Src", "/Assets/*.json", "/Assets/*.ttf", "/Tests", "/main.py", "/README.md", "/pyproject.toml", "/uv.lock", "/LICENSE*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "numpy<2.2.0",
     "pillow>=12.0.0",
     "pydot>=4.0.1",
-    "tensorflow>=2.19.0",
+    "tensorflow==2.19.0",
     "matplotlib>=3.10.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -249,7 +249,7 @@ requires-dist = [
     { name = "numpy", specifier = "<2.2.0" },
     { name = "pillow", specifier = ">=12.0.0" },
     { name = "pydot", specifier = ">=4.0.1" },
-    { name = "tensorflow", specifier = ">=2.19.0" },
+    { name = "tensorflow", specifier = "==2.19.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -222,9 +222,9 @@ wheels = [
 ]
 
 [[package]]
-name = "graphnet"
+name = "graphnet-constructor"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "dearpygui" },
     { name = "librosa" },


### PR DESCRIPTION
Установка текущего checkout через `pip` пока не предоставляет рабочую команду для запуска приложения и не включает необходимые runtime-ресурсы в пакет. Это изменение добавляет сборку wheel/sdist через Hatchling, точку входа `graphnet`, включение шрифтов, тем и конфигурации логирования в дистрибутив, поиск ресурсов независимо от текущей рабочей директории.

По умолчанию логи сохраняются в `~/.graphnet/logs`. Путь можно переопределить с помощью переменной окружения `GRAPHNET_LOG_DIR`.

TensorFlow закреплён на 2.19.0 для устранения падения при запуске в Linux. Проверки CI пройдены.

Closes #96